### PR TITLE
Added dialog when import conflict is detected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4390,11 +4390,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4407,15 +4409,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4518,7 +4523,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4528,6 +4534,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4540,17 +4547,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4567,6 +4577,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4639,7 +4650,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4649,6 +4661,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4754,6 +4767,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -59,7 +59,6 @@ class App extends Component {
       confirmCounterdeleteAllChecked: 0,
       confirmCounterdeleteAllItems: 0,
       snackbarOpen: false,
-      modalImportConflictOpen: false,
       itemsToBeImport: []
     }
 
@@ -121,10 +120,7 @@ class App extends Component {
         })
       })
     } else {
-      this.setState({
-        itemsToBeImport: newItems,
-        modalImportConflictOpen: true
-      })
+      this.setState({ itemsToBeImport: newItems })
     }
   }
 
@@ -205,11 +201,11 @@ class App extends Component {
       confirmCounterdeleteAllChecked,
       confirmCounterdeleteAllItems,
       snackbarOpen,
-      modalImportConflictOpen,
       itemsToBeImport
     } = this.state
 
     const menuAppOpen = Boolean(appMenuAnchorEl)
+    const modalImportConflictOpen = itemsToBeImport.length > 0
 
     return (
       <MuiThemeProvider theme={theme}>
@@ -371,7 +367,7 @@ class App extends Component {
         />
         <Dialog
           open={modalImportConflictOpen}
-          onClose={() => this.setState({ modalImportConflictOpen: false })}
+          onClose={() => this.setState({ itemsToBeImport: [] })}
           aria-labelledby='dialog-title'
           aria-describedby='dialog-description'
         >
@@ -384,7 +380,7 @@ class App extends Component {
           <DialogActions>
             <Button variant='contained' color='primary' onClick={() => {
               this.overwriteItems([...items, ...itemsToBeImport]).then(() => {
-                this.setState({ modalImportConflictOpen: false }, () => {
+                this.setState({ itemsToBeImport: [] }, () => {
                   window.location.href = `${window.location.origin}${window.location.pathname}`
                 })
               })
@@ -393,14 +389,14 @@ class App extends Component {
             </Button>
             <Button variant='contained' color='secondary' onClick={() => {
               this.overwriteItems(itemsToBeImport).then(() => {
-                this.setState({ modalImportConflictOpen: false }, () => {
+                this.setState({ itemsToBeImport: [] }, () => {
                   window.location.href = `${window.location.origin}${window.location.pathname}`
                 })
               })
             }}>
               Overwrite existing list
             </Button>
-            <Button variant='contained' color='default' onClick={() => this.setState({ modalImportConflictOpen: false })}>
+            <Button variant='contained' color='default' onClick={() => this.setState({ itemsToBeImport: [] })}>
               Nothing
             </Button>
           </DialogActions>

--- a/src/App.js
+++ b/src/App.js
@@ -73,6 +73,7 @@ class App extends Component {
     this.onDelete = this.onDelete.bind(this)
     this.onDeleteAllChecked = this.onDeleteAllChecked.bind(this)
     this.onDeleteAllItems = this.onDeleteAllItems.bind(this)
+    this.handleImportConflictClose = this.handleImportConflictClose.bind(this)
   }
 
   componentDidMount () {
@@ -187,6 +188,13 @@ class App extends Component {
           resolve()
         })
       })
+    })
+  }
+
+  handleImportConflictClose () {
+    // Empty itemsToBeImport then drop all query variables
+    this.setState({ itemsToBeImport: [] }, () => {
+      window.location.href = `${window.location.origin}${window.location.pathname}`
     })
   }
 
@@ -367,7 +375,7 @@ class App extends Component {
         />
         <Dialog
           open={modalImportConflictOpen}
-          onClose={() => this.setState({ itemsToBeImport: [] })}
+          onClose={this.handleImportConflictClose}
           aria-labelledby='dialog-title'
           aria-describedby='dialog-description'
         >
@@ -380,23 +388,21 @@ class App extends Component {
           <DialogActions>
             <Button variant='contained' color='primary' onClick={() => {
               this.overwriteItems([...items, ...itemsToBeImport]).then(() => {
-                this.setState({ itemsToBeImport: [] }, () => {
-                  window.location.href = `${window.location.origin}${window.location.pathname}`
-                })
+                this.handleImportConflictClose()
               })
             }}>
               Merge
             </Button>
             <Button variant='contained' color='secondary' onClick={() => {
               this.overwriteItems(itemsToBeImport).then(() => {
-                this.setState({ itemsToBeImport: [] }, () => {
-                  window.location.href = `${window.location.origin}${window.location.pathname}`
-                })
+                this.handleImportConflictClose()
               })
             }}>
               Overwrite
             </Button>
-            <Button variant='contained' color='default' style={{ position: 'absolute', left: 4 }} onClick={() => this.setState({ itemsToBeImport: [] })}>
+            <Button variant='contained' color='default' style={{ position: 'absolute', left: 4 }} onClick={() => {
+              this.handleImportConflictClose()
+            }}>
               Cancel
             </Button>
           </DialogActions>

--- a/src/App.js
+++ b/src/App.js
@@ -385,7 +385,7 @@ class App extends Component {
                 })
               })
             }}>
-              Merge lists
+              Merge
             </Button>
             <Button variant='contained' color='secondary' onClick={() => {
               this.overwriteItems(itemsToBeImport).then(() => {
@@ -394,10 +394,10 @@ class App extends Component {
                 })
               })
             }}>
-              Overwrite existing list
+              Overwrite
             </Button>
-            <Button variant='contained' color='default' onClick={() => this.setState({ itemsToBeImport: [] })}>
-              Nothing
+            <Button variant='contained' color='default' style={{ position: 'absolute', left: 4 }} onClick={() => this.setState({ itemsToBeImport: [] })}>
+              Cancel
             </Button>
           </DialogActions>
         </Dialog>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/273553/45693695-31f7cf00-bb4d-11e8-87ec-7d42b1f67bb4.png)


When users use share/import link with valid items, 4 things can happen:
1. If user has already an empty list then items will just be imported without user being prompted
2. User can merge current list and imported list
3. User can overwrite existing list
4. User can do nothing and that's the only step that app will not clear import string in the address bar.