### PR TITLE
Removed drag handle and added edit/delete in item options

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,6 @@ import {
   Add as AddIcon,
   MoreVert as MoreVertIcon,
   Share as ShareIcon,
-  Edit as EditIcon,
   DeleteSweep as DeleteSweepIcon,
   Close as CloseIcon
 } from '@material-ui/icons'
@@ -57,7 +56,6 @@ class App extends Component {
       modalAddItemsOpen: false,
       textareaAddItems: '',
       appMenuAnchorEl: null,
-      appEditMode: false,
       confirmCounterdeleteAllChecked: 0,
       confirmCounterdeleteAllItems: 0,
       snackbarCopiedConfirmOpen: false,
@@ -172,8 +170,13 @@ class App extends Component {
   }
 
   onDelete (id) {
-    const items = this.state.items.filter(item => item.id !== id)
-    this.overwriteItems(items)
+    this.setState({
+      itemsBeforeDeletion: this.state.items,
+      snackbarDeletedUndoOpen: true
+    }, () => {
+      const items = this.state.items.filter(item => item.id !== id)
+      this.overwriteItems(items)
+    })
   }
 
   onDeleteAllChecked () {
@@ -225,7 +228,6 @@ class App extends Component {
       modalAddItemsOpen,
       textareaAddItems,
       appMenuAnchorEl,
-      appEditMode,
       confirmCounterdeleteAllChecked,
       confirmCounterdeleteAllItems,
       snackbarCopiedConfirmOpen,
@@ -249,7 +251,7 @@ class App extends Component {
               title={`Version ${window.appVersion}`}
             >List List</Typography>
             <IconButton
-              aria-label='options'
+              aria-label='app options'
               aria-owns={menuAppOpen ? 'app-options' : null}
               aria-haspopup='true'
               onClick={(e) => this.setState({ appMenuAnchorEl: e.currentTarget })}
@@ -286,7 +288,6 @@ class App extends Component {
               onEdit={this.onEdit}
               onDelete={this.onDelete}
               onSortStart={this.onSortStart}
-              appEditMode={appEditMode}
             />
           }
         </div>
@@ -325,10 +326,6 @@ class App extends Component {
               <ListItemText inset primary='Copy share link' />
             </MenuItem>
           </CopyToClipboard>
-          <MenuItem onClick={() => this.setState({ appEditMode: !appEditMode, appMenuAnchorEl: null })}>
-            <ListItemIcon><EditIcon /></ListItemIcon>
-            <ListItemText inset primary={`${appEditMode ? 'Exit' : 'Enter'} edit mode`} />
-          </MenuItem>
           {isAnyItemsChecked &&
             <MenuItem onClick={() => {
               if (confirmCounterdeleteAllChecked === 1) {
@@ -440,7 +437,7 @@ class App extends Component {
           <DialogTitle id='dialog-title'>Import conflict detected</DialogTitle>
           <DialogContent>
             <DialogContentText id='dialog-description'>
-              You are trying to import {pluralItems(itemsToBeImport.length)} but there are already {pluralItems(items.length)} on your list. What do you want to do?
+            You are trying to import {pluralItems(itemsToBeImport.length)} but there are already {pluralItems(items.length)} on your list. What do you want to do?
             </DialogContentText>
           </DialogContent>
           <DialogActions>

--- a/src/components/ItemItem/ItemItem.js
+++ b/src/components/ItemItem/ItemItem.js
@@ -1,11 +1,9 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import {
-  SortableElement,
-  SortableHandle
-} from 'react-sortable-hoc'
+import { SortableElement } from 'react-sortable-hoc'
 import {
   ListItem,
+  ListItemIcon,
   ListItemText,
   IconButton,
   MenuItem,
@@ -17,7 +15,7 @@ import {
   Button
 } from '@material-ui/core'
 import {
-  DragIndicator as DragIndicatorIcon,
+  MoreVert as MoreIcon,
   Edit as EditIcon,
   Check as CheckIcon,
   Close as CloseIcon,
@@ -31,15 +29,15 @@ class ItemItem extends Component {
     this.state = {
       editingItem: false,
       editingText: '',
-      deleteConfirmAnchorEl: null
+      itemMenuAnchorEl: null
     }
   }
 
   render () {
-    const { item, isItemActive, onCheck, onEdit, onDelete, appEditMode } = this.props
-    const { editingItem, editingText, deleteConfirmAnchorEl } = this.state
+    const { item, isItemActive, onCheck, onEdit, onDelete } = this.props
+    const { editingItem, editingText, itemMenuAnchorEl } = this.state
 
-    const deleteConfirmOpen = Boolean(deleteConfirmAnchorEl)
+    const itemMenuOpen = Boolean(itemMenuAnchorEl)
 
     return (
       <ListItem
@@ -59,39 +57,33 @@ class ItemItem extends Component {
             }
             onClick={() => onCheck(item.id)}
           />
-          {!appEditMode &&
-            <DragHandle />
-          }
-          {appEditMode &&
-            <Fragment>
-              <IconButton
-                aria-label='edit'
-                onClick={() => this.setState({ editingItem: true, editingText: item.text })}
-              >
-                <EditIcon />
-              </IconButton>
-              <IconButton
-                aria-label='delete'
-                aria-owns={deleteConfirmOpen ? 'item-menu' : null}
-                aria-haspopup='true'
-                onClick={(e) => this.setState({ deleteConfirmAnchorEl: e.currentTarget })}
-              >
-                <DeleteIcon />
-              </IconButton>
-            </Fragment>
-          }
+          <IconButton
+            aria-label='item options'
+            aria-owns={itemMenuOpen ? 'item-menu' : null}
+            aria-haspopup='true'
+            onClick={(e) => this.setState({ itemMenuAnchorEl: e.currentTarget })}
+          >
+            <MoreIcon />
+          </IconButton>
           <Menu
             id='item-menu'
-            anchorEl={deleteConfirmAnchorEl}
-            open={deleteConfirmOpen}
-            onClose={() => this.setState({ deleteConfirmAnchorEl: null })}
+            anchorEl={itemMenuAnchorEl}
+            open={itemMenuOpen}
+            onClose={() => this.setState({ itemMenuAnchorEl: null })}
           >
-            <MenuItem onClick={() => onDelete(item.id)}>Are you sure?</MenuItem>
+            <MenuItem onClick={() => this.setState({ editingItem: true, editingText: item.text, itemMenuAnchorEl: null })}>
+              <ListItemIcon><EditIcon /></ListItemIcon>
+              <ListItemText inset primary='Edit' />
+            </MenuItem>
+            <MenuItem onClick={() => onDelete(item.id)}>
+              <ListItemIcon><DeleteIcon /></ListItemIcon>
+              <ListItemText inset primary='Delete' />
+            </MenuItem>
           </Menu>
         </Fragment>
         }
         {editingItem &&
-          <Grid container>
+          <Grid container className='d-block d-sm-flex'>
             <Grid item style={{ flexGrow: 1 }}>
               <TextField
                 fullWidth
@@ -100,19 +92,19 @@ class ItemItem extends Component {
                 value={editingText}
               />
             </Grid>
-            <Grid item>
-              <Button className='ml-3' variant='contained' size='small' color='primary' onClick={() => {
+            <Grid item className='mt-3 mt-sm-0'>
+              <Button className='ml-2' variant='contained' size='small' color='primary' onClick={() => {
                 onEdit(item.id, editingText)
                 this.setState({ editingItem: false, editingText: '' })
               }}>
-                <CheckIcon className='mr-2' style={{ fontSize: 20 }} />
-                Save
+                <CheckIcon style={{ fontSize: 20 }} />
+                <span className='d-none d-sm-block ml-1'>Save</span>
               </Button>
-              <Button className='ml-3' variant='contained' size='small' onClick={() => {
+              <Button className='ml-2' variant='contained' size='small' onClick={() => {
                 this.setState({ editingItem: false, editingText: '' })
               }}>
-                <CloseIcon className='mr-2' style={{ fontSize: 20 }} />
-                Cancel
+                <CloseIcon style={{ fontSize: 20 }} />
+                <span className='d-none d-sm-block ml-1'>Cancel</span>
               </Button>
             </Grid>
           </Grid>
@@ -127,15 +119,10 @@ ItemItem.propTypes = {
   isItemActive: PropTypes.bool.isRequired,
   onCheck: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired,
-  appEditMode: PropTypes.bool
+  onDelete: PropTypes.func.isRequired
 }
 
 ItemItem.defaultProps = {
-  appEditMode: false
 }
 
 export default SortableElement(ItemItem)
-
-// This can be any component you want
-const DragHandle = SortableHandle(() => <DragIndicatorIcon className='cursor-grab' />)

--- a/src/components/ListList/ListList.js
+++ b/src/components/ListList/ListList.js
@@ -5,7 +5,7 @@ import List from '@material-ui/core/List'
 
 import ItemItem from '../ItemItem'
 
-const ListList = ({ items, sortingItemIndex, onCheck, onEdit, onDelete, onSortStart, onSortEnd, appEditMode }) => {
+const ListList = ({ items, sortingItemIndex, onCheck, onEdit, onDelete, onSortStart, onSortEnd }) => {
   return (
     <SortableList
       items={items}
@@ -15,10 +15,11 @@ const ListList = ({ items, sortingItemIndex, onCheck, onEdit, onDelete, onSortSt
       onDelete={onDelete}
       onSortStart={onSortStart}
       onSortEnd={onSortEnd}
-      appEditMode={appEditMode}
       lockAxis='y'
-      useDragHandle
       useWindowAsScrollContainer
+      transitionDuration={600}
+      pressDelay={100}
+      helperClass='item--active'
     />
   )
 }
@@ -30,20 +31,18 @@ ListList.propTypes = {
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   onSortStart: PropTypes.func.isRequired,
-  onSortEnd: PropTypes.func.isRequired,
-  appEditMode: PropTypes.bool
+  onSortEnd: PropTypes.func.isRequired
 }
 
 ListList.defaultProps = {
   items: [],
-  sortingItemIndex: null,
-  appEditMode: false
+  sortingItemIndex: null
 }
 
 export default ListList
 
 // Wrapper
-const SortableList = SortableContainer(({ items, sortingItemIndex, onCheck, onEdit, onDelete, appEditMode }) => (
+const SortableList = SortableContainer(({ items, sortingItemIndex, onCheck, onEdit, onDelete }) => (
   <List style={{ padding: 0 }}>
     {items.map((item, index) => (
       <ItemItem
@@ -54,7 +53,6 @@ const SortableList = SortableContainer(({ items, sortingItemIndex, onCheck, onEd
         onCheck={onCheck}
         onEdit={onEdit}
         onDelete={onDelete}
-        appEditMode={appEditMode}
       />
     ))}
   </List>

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,10 @@ body {
   font-family: sans-serif;
 }
 
+.item--active {
+  background-color: #f0f0f0 !important;
+}
+
 .container {
   width: 100%;
   padding-right: 15px;
@@ -176,7 +180,6 @@ body {
   .mb-sm-auto, .my-sm-auto { margin-bottom: auto !important; }
   .ml-sm-auto, .mx-sm-auto { margin-left: auto !important; }
 }
-
 @media (min-width: 768px) {
   .m-md-0 { margin: 0 !important; }
   .mt-md-0, .my-md-0 { margin-top: 0 !important; }
@@ -244,7 +247,6 @@ body {
   .mb-md-auto, .my-md-auto { margin-bottom: auto !important; }
   .ml-md-auto, .mx-md-auto { margin-left: auto !important; }
 }
-
 @media (min-width: 992px) {
   .m-lg-0 { margin: 0 !important; }
   .mt-lg-0, .my-lg-0 { margin-top: 0 !important; }
@@ -312,7 +314,6 @@ body {
   .mb-lg-auto, .my-lg-auto { margin-bottom: auto !important; }
   .ml-lg-auto, .mx-lg-auto { margin-left: auto !important; }
 }
-
 @media (min-width: 1200px) {
   .m-xl-0 { margin: 0 !important; }
   .mt-xl-0, .my-xl-0 { margin-top: 0 !important; }
@@ -386,3 +387,69 @@ body {
 .text-center { text-align: center !important; }
 
 .cursor-grab { cursor: grab; }
+
+.d-none { display: none !important; }
+.d-inline { display: inline !important; }
+.d-inline-block { display: inline-block !important; }
+.d-block { display: block !important; }
+.d-table { display: table !important; }
+.d-table-row { display: table-row !important; }
+.d-table-cell { display: table-cell !important; }
+.d-flex { display: -ms-flexbox !important; display: flex !important; }
+.d-inline-flex { display: -ms-inline-flexbox !important; display: inline-flex !important; }
+
+@media (min-width: 576px) {
+  .d-sm-none { display: none !important; }
+  .d-sm-inline { display: inline !important; }
+  .d-sm-inline-block { display: inline-block !important; }
+  .d-sm-block { display: block !important; }
+  .d-sm-table { display: table !important; }
+  .d-sm-table-row { display: table-row !important; }
+  .d-sm-table-cell { display: table-cell !important; }
+  .d-sm-flex { display: -ms-flexbox !important; display: flex !important; }
+  .d-sm-inline-flex { display: -ms-inline-flexbox !important; display: inline-flex !important; }
+}
+@media (min-width: 768px) {
+  .d-md-none { display: none !important; }
+  .d-md-inline { display: inline !important; }
+  .d-md-inline-block { display: inline-block !important; }
+  .d-md-block { display: block !important; }
+  .d-md-table { display: table !important; }
+  .d-md-table-row { display: table-row !important; }
+  .d-md-table-cell { display: table-cell !important; }
+  .d-md-flex { display: -ms-flexbox !important; display: flex !important; }
+  .d-md-inline-flex { display: -ms-inline-flexbox !important; display: inline-flex !important; }
+}
+@media (min-width: 992px) {
+  .d-lg-none { display: none !important; }
+  .d-lg-inline { display: inline !important; }
+  .d-lg-inline-block { display: inline-block !important; }
+  .d-lg-block { display: block !important; }
+  .d-lg-table { display: table !important; }
+  .d-lg-table-row { display: table-row !important; }
+  .d-lg-table-cell { display: table-cell !important; }
+  .d-lg-flex { display: -ms-flexbox !important; display: flex !important; }
+  .d-lg-inline-flex { display: -ms-inline-flexbox !important; display: inline-flex !important; }
+}
+@media (min-width: 1200px) {
+  .d-xl-none { display: none !important; }
+  .d-xl-inline { display: inline !important; }
+  .d-xl-inline-block { display: inline-block !important; }
+  .d-xl-block { display: block !important; }
+  .d-xl-table { display: table !important; }
+  .d-xl-table-row { display: table-row !important; }
+  .d-xl-table-cell { display: table-cell !important; }
+  .d-xl-flex { display: -ms-flexbox !important; display: flex !important; }
+  .d-xl-inline-flex { display: -ms-inline-flexbox !important; display: inline-flex !important; }
+}
+@media print {
+  .d-print-none { display: none !important; }
+  .d-print-inline { display: inline !important; }
+  .d-print-inline-block { display: inline-block !important; }
+  .d-print-block { display: block !important; }
+  .d-print-table { display: table !important; }
+  .d-print-table-row { display: table-row !important; }
+  .d-print-table-cell { display: table-cell !important; }
+  .d-print-flex { display: -ms-flexbox !important; display: flex !important; }
+  .d-print-inline-flex { display: -ms-inline-flexbox !important; display: inline-flex !important; }
+}


### PR DESCRIPTION
- Remove the drag handle to add item option menu with the edit and delete options
- Removed edit mode option from app option menu
- Fixed the item edit ui/ux on mobile
- Added undo feature for item deletion just like bulk deletion from app option menu and removed the confirmation step
- To sort the list you have to press the item until the background changes and then it's movable

![image](https://user-images.githubusercontent.com/273553/45811357-59b97500-bcbc-11e8-9f81-07b52fd5de91.png)

![image](https://user-images.githubusercontent.com/273553/45810775-f5e27c80-bcba-11e8-8a35-43132c278c30.png)